### PR TITLE
Add Scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Note: Supports NodeJS 12+.  No dependencies!
 
 Add the `--help` flag for more info.
 
-Note: Be sure to run in terminals that support 256 colors.  Minimum required terminal screen dimensions: 156 columns x 46 rows.
+Note:
+- Be sure to run in terminals that support 256 colors.
+- Minimum required terminal screen dimensions: 156 columns x 46 rows.  [See scrolling](https://github.com/spirometaxas/periodic-table-cli#scrolling) for more info.  
 
 ## Features
 ### Browse
@@ -250,6 +252,14 @@ $ periodic-table-cli --mode=app --atomic-number=<number>
 $ periodic-table-cli --mode=app --symbol=<symbol>
 $ periodic-table-cli --mode=app --name=<name>
 ```
+
+### Scrolling
+The minimum required terminal screen dimensions are 156 columns x 46 rows.  When using a smaller screen, some components may be cut off.  To fix this, either make the screen bigger or use scrolling to pan across the screen:
+
+- Use `COMMA` (`,`) to scroll up.
+- Use `PERIOD` (`.`) to scroll down.
+- Use `LEFT CARROT` (`<`) to scroll left.
+- Use `RIGHT CARROT` (`>`) to scroll right.
 
 ## Data Sources
 Data used in the app is stored in an easy to edit [data file](https://github.com/spirometaxas/periodic-table-cli/blob/main/src/data.js).  The data is mostly imported from [PubChem](https://pubchem.ncbi.nlm.nih.gov/periodic-table/). 

--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,13 @@ const KeyMap = {
     ],
     NUMBERS: [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ],
     SPECIAL_CHARACTERS: [ '-', ' ' ],
+    COMMA: ',',
+    PERIOD: '.',
+    LEFT_CARROT: '<',
+    RIGHT_CARROT: '>',
 }
+
+const MINIMUM_SUPPORTED_DIMENSIONS = { rows: 46, columns: 156 };
 
 const DEGUG_MODE = false;
 
@@ -76,6 +82,14 @@ class App {
                     handled = this.stateController.processBackspace();
                 } else if (KeyMap.LETTERS.includes(key) || KeyMap.NUMBERS.includes(key) || KeyMap.SPECIAL_CHARACTERS.includes(key)) {
                     handled = this.stateController.processSearchInput(key);
+                } else if (key === KeyMap.COMMA) {
+                    handled = this.dashboard.scrollUp();
+                } else if (key === KeyMap.PERIOD) {
+                    handled = this.dashboard.scrollDown();
+                } else if (key === KeyMap.LEFT_CARROT) {
+                    handled = this.dashboard.scrollLeft();
+                } else if (key === KeyMap.RIGHT_CARROT) {
+                    handled = this.dashboard.scrollRight();
                 }
 
                 if (handled) {
@@ -93,6 +107,7 @@ class App {
         // On terminal resize
         process.on("SIGWINCH", () => {
             try {
+                this.dashboard.updateScrollingOnResize()
                 this._draw(true);
                 process.stdout.write('\u001B[?25l');  // Hise cursor
             } catch(e) {
@@ -110,6 +125,14 @@ class App {
         process.stdout.write('\u001B[?25h');    // Show cursor
         if (message) {
             console.log(message);
+        } else if (process.stdout.rows < MINIMUM_SUPPORTED_DIMENSIONS.rows || process.stdout.columns < MINIMUM_SUPPORTED_DIMENSIONS.columns) {
+            console.log('\n' +
+                ' Warning: Current screen dimensions are smaller than minimum supported dimensions, and some screen components may have been cut off.\n' +
+                ' To fix this, either make the screen bigger or use scrolling to pan across the screen:\n' +
+                '   - Use COMMA (,) to scroll up\n' +
+                '   - Use PERIOD (.) to scroll down\n' +
+                '   - Use LEFT CARROT (<) to scroll left\n' +
+                '   - Use RIGHT CARROT (>) to scroll right\n');
         }
         process.exit();
     }

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -165,6 +165,7 @@ class Dashboard {
 
     constructor() {
         this.board = this._parseBoard();
+        this.scrolling = { x: 0, y: 0 };
         this._initDataOnBoard();
         this._saveBoard();
 
@@ -820,11 +821,58 @@ class Dashboard {
                     rOffset = parseInt((fullRows - this.board.length) * this.VERTICAL_RATIO);
                 }
 
-                fullBoard[rOffset + r][cOffset + c] = this.board[r][c];
+                fullBoard[rOffset + r][cOffset + c] = this.board[r + this.scrolling.y][c + this.scrolling.x];
             }
         }
 
         return fullBoard;
+    }
+
+    scrollUp() {
+        const fullRows = process.stdout.rows;
+        if (fullRows < this.board.length && this.scrolling.y > 0) {
+            this.scrolling.y -= 1;
+            return true;
+        }
+        return false;
+    }
+
+    scrollDown() {
+        const fullRows = process.stdout.rows;
+        if (fullRows < this.board.length && this.scrolling.y + fullRows < this.board.length) {
+            this.scrolling.y += 1;
+            return true;
+        }
+        return false;
+    }
+
+    scrollLeft() {
+        const fullColumns = process.stdout.columns;
+        if (fullColumns < this.board[0].length && this.scrolling.x > 0) {
+            this.scrolling.x -= 1;
+            return true;
+        }
+        return false;
+    }
+
+    scrollRight() {
+        const fullColumns = process.stdout.columns;
+        if (fullColumns < this.board[0].length && this.scrolling.x + fullColumns < this.board[0].length) {
+            this.scrolling.x += 1;
+            return true;
+        }
+        return false;
+    }
+
+    updateScrollingOnResize() {
+        const fullRows = process.stdout.rows;
+        const fullColumns = process.stdout.columns;
+        if (this.scrolling.y + fullRows > this.board.length) {
+            this.scrolling.y = Math.max(this.board.length - fullRows, 0);
+        }
+        if (this.scrolling.x + fullColumns > this.board[0].length) {
+            this.scrolling.x = Math.max(this.board[0].length - fullColumns, 0);
+        }
     }
 
     _draw() {


### PR DESCRIPTION
The minimum required terminal screen dimensions are 156 columns x 46 rows.  When using a smaller screen, some components may be cut off.  To fix this, either make the screen bigger or use scrolling to pan across the screen:

- Use `COMMA` (`,`) to scroll up.
- Use `PERIOD` (`.`) to scroll down.
- Use `LEFT CARROT` (`<`) to scroll left.
- Use `RIGHT CARROT` (`>`) to scroll right.